### PR TITLE
feature: enable USB_RESET hook, and reset usb when hosts resets

### DIFF
--- a/main.c
+++ b/main.c
@@ -36,6 +36,7 @@
 #include "reportdesc.h"
 
 #define MAX_REPORTS	2
+#define USB_RESET_HOOK(resetStarts)     if(!resetStarts){usbReset();}
 
 #undef NONSTOP_VIBRATION
 #undef WAIT_FOR_PAD


### PR DESCRIPTION
I don't know if you still accept PR's for this ancient version, but ive been using this project for years, and (very crappy) personal fork of this + the nes/snes code. 
However, i hated the fact that after every windows reboot, i had to unplug and plug it back in, because the mcu kept getting power over usb, meaning the usb was never reset.
Today i found that v-usb has a hook on the reset request from host, in which we deal with it with the usbReset function.
I don't know if this is correct, but it does seem to work, as the device enumerated correctly after a reboot.

this fix could also be applied to your generic usb controller project